### PR TITLE
[Fix] Keep multiple dependencies for scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (options) {
 			}
 
 			if (options.js && options.jsHandle) {
-				var regexJs = new RegExp("(wp_(?:register|enqueue)_script\\(\\s?'" + options.jsHandle + "',(\\s*[^,]+,){2})\\s*[^,]+(,\\s*[^\\)]+)?\\);");
+				var regexJs = new RegExp("(wp_(?:register|enqueue)_script\\(\\s?'" + options.jsHandle + "',(\\s*[^,]+,\\s*.+,))\\s*'[a-zA-Z0-9]+'\\s*(,\\s*[^\\)]+)?\\);");
 				var hashJs = md5(options.js);
 				file.contents = new Buffer(String(file.contents).replace(regexJs, "$1 '" + hashJs + "'$3);"));
 			}


### PR DESCRIPTION
Problem:
The old regex didn't select multiple dependencies (because of the comma used to separate this array).

Solution:
- Change the 2nd capture group so dependencies can include commas.
- Make the selection for the hash and the optional `$in_footer` parameter more specific to assist the 2nd group capturing.

Notes:
- This may also be a solution for multiple dependencies on styles. (not included here)
- Remaining problem: any commas used in the part where the `$src` parameter is expressed will still mess up the replacing.